### PR TITLE
feat: Propagate Timeout on sleep promise

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,10 +79,12 @@ function hookedReject(reject: RejectFunction, hook: () => void, reason: Error) {
 	reject(reason);
 }
 
-export function sleep(ms: number | Number): Promise<void> {
-	return new Promise((resolve) => {
-		setTimeout(resolve, +ms);
+type Timeout = ReturnType<typeof setTimeout>;
+export function sleep(ms: number | Number): Promise<void> & Timeout {
+	const promise = new Promise<void>((resolve) => {
+		Object.assign(promise, setTimeout(resolve, +ms));
 	});
+	return promise as Promise<void> & Timeout;
 }
 
 export interface Callable {

--- a/test/defer.ts
+++ b/test/defer.ts
@@ -74,6 +74,11 @@ describe('defer', () => {
 		backup.resolve(2);
 		assert.equal(await backup, 2);
 	});
+	it('sleep can unref', () => {
+		const p = sleep(1000);
+		p.unref();
+		assert(!p.hasRef());
+	});
 });
 
 function isErrorCode(e: any): e is Error & { code: string } {


### PR DESCRIPTION
Just a thought here.  Was thinking we might want to propagate the ability to `unref` calls to things like `WaitScreen` in our relish testing.  Having access to the underlying `timeout` object returned by `setTimeout` might be helpful in other cases regardless.